### PR TITLE
make HOOGLE_URL configurable; add gradle build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ HoogleIt
 Intellij idea plugin for searching on Hoogle
 
 v0.3 or earlier: A shameless ripoff of GoogleIt plugin: https://github.com/neronmoon/GoogleIt
+
 v0.4: Make HOOGLE_URL configurable via environment variable
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 HoogleIt
 ========
 
-Intellij idea plugin
+Intellij idea plugin for searching on Hoogle
 
-A shameless ripoff of GoogleIt plugin: https://github.com/neronmoon/GoogleIt
+v0.3 or earlier: A shameless ripoff of GoogleIt plugin: https://github.com/neronmoon/GoogleIt
+v0.4: Make HOOGLE_URL configurable via environment variable
+
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,42 @@
+//plugins {
+//  id "org.jetbrains.intellij" version "0.3.12"
+//}
+//
+//apply plugin: 'java'
+
+plugins {
+    id "org.jetbrains.intellij" version "0.2.16"
+}
+
+ext {
+    javaVersion = '1.8'
+}
+
+allprojects {
+
+    apply plugin: 'java'
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+
+    apply plugin: 'org.jetbrains.intellij'
+
+    intellij {
+        version = '2017.3'
+        pluginName = 'HoogleIt'
+        updateSinceUntilBuild = false
+    }
+
+    repositories {
+        mavenCentral()
+    }
+
+}
+
+
+
+def getPluginVersion() {
+        return "0.4"
+}
+
+
+

--- a/src/main/java/org/idea/plugin/HoogleIt/HoogleItSelected.java
+++ b/src/main/java/org/idea/plugin/HoogleIt/HoogleItSelected.java
@@ -14,8 +14,10 @@ import java.net.*;
  * Created by #ROOT
  * Date: 20.02.14
  * Time: 20:35
+ * Updated by Laura Dietz, Nov 24, 2018:  Read Hoogle URL from environment variable HOOGLE_URL
  * Contact me: alistar.neron@gmail.com
  * Contact me: mrkafk@gmail.com
+ * Contact me: dietz@smart-cactus.org
  */
 public class HoogleItSelected extends EditorAction {
 
@@ -56,7 +58,14 @@ public class HoogleItSelected extends EditorAction {
 
             if( searchText.length() < 1 ) return;
             try {
-                String headerUrl = "https://www.haskell.org/hoogle/?hoogle=";
+                String headerUrlDefault = "https://www.haskell.org/hoogle/?hoogle=";
+		String headerUrl = "";
+		try {
+			headerUrl= System.getenv().containsKey("HOOGLE_URL")?System.getenv("HOOGLE_URL"):headerUrlDefault;
+		} catch (java.lang.SecurityException ex) {
+			System.err.println("Security prevents access to environment variable \"HOOGLE_URL\". Using default \""+headerUrlDefault+"\". ");
+			headerUrl = headerUrlDefault;
+		} 
                 String encodedUrl = URLEncoder.encode(searchText.replaceAll("\n", ""),"UTF-8");
 
                 GHandler.openURI(new URL(headerUrl+encodedUrl).toURI());

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,23 +1,24 @@
-<idea-plugin version="2">
+<idea-plugin use-idea-classloader="true">
   <id>org.root.HoogleIt</id>
   <name>HoogleIt</name>
-  <version>0.3</version>
-  <vendor email="aistar.neron@gmail.com, mrkafk@gmail.com" url="https://github.com/mrkafk/HoogleIt">ROOT, Marcin Krol</vendor>
+  <version>0.4</version>
+  <vendor email="aistar.neron@gmail.com, mrkafk@gmail.com, dietz@smart-cactus.org" url="https://github.com/laura-dietz/HoogleIt">ROOT, Marcin Krol, Laura Dietz</vendor>
 
   <description><![CDATA[
      Haskell - Hoogle instant search. <br>
      Use ctrl+shift+h to search selected text in Hoogle.
      If no text is selected, the word under cursor is selected.
+     To search local hoogle instance, set environment variable $HOOGLE_URL to search URL (default is "http://hoogle.haskell.org/?hoogle=")
       ]]></description>
 
   <change-notes><![CDATA[
-      Init<br>
-      <small>most HTML tags may be used</small>
+      Init
+      0.4: make hoogle url configurable; update to new idea plugin infrastructure; use gradle
       ]]>
   </change-notes>
 
   <!-- please see http://confluence.jetbrains.net/display/IDEADEV/Build+Number+Ranges for description -->
-  <idea-version since-build="107.105"/>
+  <idea-version since-build="173"/>
 
   <!-- please see http://confluence.jetbrains.net/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
        on how to target different products -->


### PR DESCRIPTION
This allows the IntelliJ HoogleIt plugin against local hoogle instances. Additionally we added the gradle build system (recommended for IntelliJ plugin development).

- HOOGLE_URL configurable as environment variable to allow for local
hoogle instances.

- update build script to modern idea plugin infrastructure

- switch to gradle

- bump version number 0.4